### PR TITLE
Support brackets for querystring arrays

### DIFF
--- a/lib/pd.js
+++ b/lib/pd.js
@@ -10,7 +10,7 @@ module.exports = Client;
 // Required Modules
 //
 const req = require('request');
-const querystring = require('querystring');
+const querystring = require('query-string');
 
 
 ////////////////////////////////////////////////////////////////////////////
@@ -31,7 +31,7 @@ const request = (options => {
 });
 
 let options = (url, method, key, qs, body) =>{
-    qs = qs ? '?' + querystring.stringify(qs) : '';
+    qs = qs ? '?' + querystring.stringify(qs, {arrayFormat: 'bracket'}) : '';
     let _option =  {
         uri: baseUrl + url + qs,
         method: method,

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "homepage": "https://github.com/kmart2234/node-pagerduty#readme",
   "dependencies": {
+    "query-string": "^6.1.0",
     "request": "2.81.0"
   },
   "devDependencies": {


### PR DESCRIPTION
PagerDuty requires the 'bracket' format for arrays. This doesn't seem to be supported by Node's built-in `querystring` module, so I've swapped for the `query-string` module instead. This appears to pretty much be a drop-in replacement, with some additional features.

Closes kmart2234/node-pagerduty#3

Tested by sending the `statuses` param to the incidents.listIncidents endpoint, and...

> $ npm run test
> 
> > node-pagerduty@1.0.2 test /Users/tim/Documents/node-pagerduty
> > mocha
> 
> ...
> 
>   163 passing (565ms)