### PR TITLE
added User-Agent header to requests

### DIFF
--- a/lib/pd.js
+++ b/lib/pd.js
@@ -11,13 +11,14 @@ module.exports = Client;
 //
 const request = require('request-promise-native');
 const querystring = require('query-string');
+const pjson = require('../package.json');
 
 
 ////////////////////////////////////////////////////////////////////////////
 // Local Variables / Functions
 //
 const baseUrl = 'https://api.pagerduty.com/';
-
+const libVersion =  `node-pagerduty / ${pjson.version}`;
 
 ////////////////////////////////////////////////////////////////////////////
 // Constructor
@@ -32,6 +33,7 @@ function Client(apiKey) {
             method: method,
             headers: {
                 'Content-Type': 'application/json',
+                'User-Agent': libVersion,
                 'Accept': 'application/json',
                 'Authorization': 'Token token=' + this.apiKey
             },
@@ -131,6 +133,7 @@ function Client(apiKey) {
                 let custHeaders = {
                     headers: {
                         'Content-Type': 'application/json',
+                        'User-Agent': libVersion,
                         "Accept": "application/vnd.pagerduty+json;version=2",
                         'Authorization': 'Token token=' + this.apiKey,
                         'From': from
@@ -244,6 +247,7 @@ function Client(apiKey) {
                     method: 'POST',
                     headers: {
                         'Content-Type': 'application/json',
+                        'User-Agent': libVersion,
                         'Authorization': 'Token token=' + this.apiKey
                     },
                     timeout: 5000,
@@ -273,6 +277,7 @@ function Client(apiKey) {
                 let custHeaders = {
                     headers: {
                         'Content-Type': 'application/json',
+                        'User-Agent': libVersion,
                         "Accept": "application/vnd.pagerduty+json;version=2",
                         'Authorization': 'Token token=' + this.apiKey,
                         'From': from
@@ -289,6 +294,7 @@ function Client(apiKey) {
                 let custHeaders = {
                     headers: {
                         'Content-Type': 'application/json',
+                        'User-Agent': libVersion,
                         "Accept": "application/vnd.pagerduty+json;version=2",
                         'Authorization': 'Token token=' + this.apiKey,
                         'From': from
@@ -305,6 +311,7 @@ function Client(apiKey) {
                 let custHeaders = {
                     headers: {
                         'Content-Type': 'application/json',
+                        'User-Agent': libVersion,
                         "Accept": "application/vnd.pagerduty+json;version=2",
                         'Authorization': 'Token token=' + this.apiKey,
                         'From': from
@@ -329,6 +336,7 @@ function Client(apiKey) {
                 let custHeaders = {
                     headers: {
                         'Content-Type': 'application/json',
+                        'User-Agent': libVersion,
                         "Accept": "application/vnd.pagerduty+json;version=2",
                         'Authorization': 'Token token=' + this.apiKey,
                         'From': from
@@ -353,6 +361,7 @@ function Client(apiKey) {
                 let custHeaders = {
                     headers: {
                         'Content-Type': 'application/json',
+                        'User-Agent': libVersion,
                         "Accept": "application/vnd.pagerduty+json;version=2",
                         'Authorization': 'Token token=' + this.apiKey,
                         'From': from
@@ -377,6 +386,7 @@ function Client(apiKey) {
                 let custHeaders = {
                     headers: {
                         'Content-Type': 'application/json',
+                        'User-Agent': libVersion,
                         "Accept": "application/vnd.pagerduty+json;version=2",
                         'Authorization': 'Token token=' + this.apiKey,
                         'From': from
@@ -409,6 +419,7 @@ function Client(apiKey) {
                 let custHeaders = {
                     headers: {
                         'Content-Type': 'application/json',
+                        'User-Agent': libVersion,
                         "Accept": "application/vnd.pagerduty+json;version=2",
                         'Authorization': 'Token token=' + this.apiKey,
                         'From': from
@@ -425,6 +436,7 @@ function Client(apiKey) {
                 let custHeaders = {
                     headers: {
                         'Content-Type': 'application/json',
+                        'User-Agent': libVersion,
                         "Accept": "application/vnd.pagerduty+json;version=2",
                         'Authorization': 'Token token=' + this.apiKey,
                         'From': from
@@ -459,6 +471,7 @@ function Client(apiKey) {
                 let custHeaders = {
                     headers: {
                         'Content-Type': 'application/json',
+                        'User-Agent': libVersion,
                         "Accept": "application/vnd.pagerduty+json;version=2",
                         'Authorization': 'Token token=' + this.apiKey,
                         'From': from
@@ -509,6 +522,7 @@ function Client(apiKey) {
                 let custHeaders = {
                     headers: {
                         'Content-Type': 'application/json',
+                        'User-Agent': libVersion,
                         "Accept": "application/vnd.pagerduty+json;version=2",
                         'Authorization': 'Token token=' + this.apiKey,
                         'From': from
@@ -819,6 +833,7 @@ function Client(apiKey) {
                 let custHeaders = {
                     headers: {
                         'Content-Type': 'application/json',
+                        'User-Agent': libVersion,
                         "Accept": "application/vnd.pagerduty+json;version=2",
                         'Authorization': 'Token token=' + this.apiKey,
                         'From': from


### PR DESCRIPTION
This PR adds the `User-Agent` header to each request to the PagerDuty API. The value is the name of the library `node-pagerduty` and the npm package number. This will help to better track how many applications and scripts are using the `node-pagerduty` library. 