### PR TITLE
Adding Event Rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ escalationPolicies.updateEscalationPolicy(id, payload)
 ```
 
 ### Event Rules
-*Note: Event Rules does not work with Bearer tokens. Only Token tokens*
+*Note: Event Rules endpoint does not work with Bearer tokens. Only Token tokens*
 https://v2.developer.pagerduty.com/docs/global-event-rules-api
 ```javascript
 eventRules.listEventRules()

--- a/README.md
+++ b/README.md
@@ -74,6 +74,16 @@ escalationPolicies.getEscalationPolicy(id, qs)
 escalationPolicies.updateEscalationPolicy(id, payload)
 ```
 
+### Event Rules
+*Note: Event Rules does not work with Bearer tokens. Only Token tokens*
+https://v2.developer.pagerduty.com/docs/global-event-rules-api
+```javascript
+eventRules.listEventRules()
+eventRules.createEventRule(id, payload)
+eventRules.deleteEventRule(id)
+eventRules.updateEventRule(id, payload)
+```
+
 ### Extension Schemas
 https://v2.developer.pagerduty.com/v2/page/api-reference#!/Extension_Schemas
 ```javascript

--- a/lib/pd.js
+++ b/lib/pd.js
@@ -179,7 +179,42 @@ function Client(apiToken, tokenType) {
             }
         }
     };
-
+// Event Rules
+// https://v2.developer.pagerduty.com/docs/global-event-rules-api
+    this.eventRules = {
+        listEventRules: async () => {
+            try {
+                return await request(this.options('event_rules', 'GET', null, null))
+            }
+            catch (err) {
+                throw new Error(err)
+            }           
+        },
+        createEventRule: async (payload) => {
+            try {
+                return await request(this.options('event_rules', 'POST', null, payload))
+            }
+            catch (err) {
+                throw new Error(err)
+            }
+        },
+        updateEventRule: async (id, payload) => {
+            try {
+                return await request(this.options('event_rules/' + id, 'PUT', null, payload))
+            }
+            catch (err) {
+                throw new Error(err)
+            }
+        },
+        deleteEventRule: async (id) => {
+            try {
+                return await request(this.options('event_rules/' + id, 'DELETE', null, null))
+            }
+            catch (err) {
+                throw new Error(err)
+            }
+        },
+    }
 // Extension Schemas
 // https://v2.developer.pagerduty.com/v2/page/api-reference#!/Extension_Schemas
     this.extensionSchemas = {

--- a/test/pd.test.js
+++ b/test/pd.test.js
@@ -252,6 +252,86 @@ describe('Client', () => {
         });
     });
 
+    describe('eventRules Section', () => {
+        describe('listEventRules function', () => {
+            context('on success', () => {
+                it('returns resolve', () => {
+                    sinon.stub(pd.eventRules, 'listEventRules').returns(Promise.resolve(fulfill));
+                    return pd.eventRules.listEventRules()
+                        .then(res => {
+                            expect(res.statusCode).to.eql(200)
+                        })
+                });
+            });
+            context('on failure', () => {
+                it('returns error', () => {
+                    return pd.eventRules.listEventRules()
+                        .catch(err => {
+                            expect(err).to.not.eql({statusCode: 200})
+                        })
+                });
+            });
+        });
+        describe('createEventRule function', () => {
+            context('on success', () => {
+                it('returns resolve', () => {
+                    sinon.stub(pd.eventRules, 'createEventRule').returns(Promise.resolve(fulfill));
+                    return pd.eventRules.createEventRule()
+                        .then(res => {
+                            console.log(res);
+                            expect(res.statusCode).to.eql(200)
+                        })
+                });
+            });
+            context('on failure', () => {
+                it('returns error', () => {
+                    return pd.eventRules.createEventRule()
+                        .catch(err => {
+                            expect(err).to.not.eql({statusCode: 200})
+                        })
+                });
+            });
+        });
+        describe('deleteEventRule function', () => {
+            context('on success', () => {
+                it('returns resolve', () => {
+                    sinon.stub(pd.eventRules, 'deleteEventRule').returns(Promise.resolve(fulfill));
+                    return pd.eventRules.deleteEventRule()
+                        .then(res => {
+                            expect(res.statusCode).to.eql(200)
+                        })
+                });
+            });
+            context('on failure', () => {
+                it('returns error', () => {
+                    return pd.eventRules.deleteEventRule()
+                        .catch(err => {
+                            expect(err).to.not.eql({statusCode: 200})
+                        })
+                });
+            });
+        });
+        describe('updateEventRule function', () => {
+            context('on success', () => {
+                it('returns resolve', () => {
+                    sinon.stub(pd.eventRules, 'updateEventRule').returns(Promise.resolve(fulfill));
+                    return pd.eventRules.updateEventRule()
+                        .then(res => {
+                            expect(res.statusCode).to.eql(200)
+                        })
+                });
+            });
+            context('on failure', () => {
+                it('returns error', () => {
+                    return pd.eventRules.updateEventRule()
+                        .catch(err => {
+                            expect(err).to.not.eql({statusCode: 200})
+                        })
+                });
+            });
+        });
+    });
+
     describe('extensionSchemas Section', () => {
         describe('listExtensionSchemas function', () => {
             context('on success', () => {


### PR DESCRIPTION
Adding support for the Event Rules endpoint. This addition supports everything the API handles today, namely Create, Update, List, and Delete operations. 